### PR TITLE
Adds trailing slash to avoid 301 redirections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ baseurl: ""
 
 markdown: kramdown
 highlighter: pygments
-permalink: /:title
+permalink: /:title/
 
 # The release of Jekyll Now that you're using
 version: v1.0.0


### PR DESCRIPTION
I noticed that links to blog posts have a 301 redirection. This should fix that.
