### PR TITLE
Fix mailto link code

### DIFF
--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -1,5 +1,5 @@
           {% if site.footer-links.dribbble %}<a href="http://dribbble.com/{{ site.footer-links.dribbble }}">{% include svg-icons/dribbble.html %}</a>{% endif %}
-          {% if site.footer-links.email %}<a href="mailto: {{ site.footer-links.email }}">{% include svg-icons/email.html %}</a>{% endif %}
+          {% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}">{% include svg-icons/email.html %}</a>{% endif %}
           {% if site.footer-links.facebook %}<a href="http://facebook.com/{{ site.footer-links.facebook }}">{% include svg-icons/facebook.html %}</a>{% endif %}
           {% if site.footer-links.flickr %}<a href="http://flickr.com/{{ site.footer-links.flickr }}">{% include svg-icons/flickr.html %}</a>{% endif %}
           {% if site.footer-links.github %}<a href="http://github.com/{{ site.footer-links.github }}">{% include svg-icons/github.html %}</a>{% endif %}


### PR DESCRIPTION
So that the created link is `mailto:email@example.com` instead of `mailto: email@example.com` (note the space after `mailto:`)
