### PR TITLE
Fix duplicate meta charset declaration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
 


### PR DESCRIPTION
Deleted duplicate meta charset attribute declaration in `/_layouts/defaults.html`

In HTML5 (as declared by jekyll-now doctype),  

``` html
<meta charset="utf-8" />
```

is equivalent to 

``` html
 <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
```
- Deleted the longer version as the shortcut is preferrable
- Ref [MetaCharsetAttribute](https://code.google.com/p/doctype-mirror/wiki/MetaCharsetAttribute)
