### PR TITLE
Fixed multiple h1 tags in pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,12 +25,16 @@
       <div class="container">
         <header class="masthead clearfix">
           <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
-          
+
           <div class="site-info">
+            {% if page.title %}
+            <p class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></p>
+            {% else %}
             <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
+            {% endif %}
             <p class="site-description">{{ site.description }}</p>
           </div>
-          
+
           <nav>
             <a href="{{ site.baseurl }}/">Blog</a>
             <a href="{{ site.baseurl }}/about">About</a>

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@ layout: default
 
 <div class="posts">
   {% for post in site.posts %}
-    <article class="post">    
-      
-      <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+    <article class="post">
+
+      <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
 
       <div class="entry">
         {{ post.content | truncatewords:40}}
       </div>
-      
+
       <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
     </article>
   {% endfor %}

--- a/style.scss
+++ b/style.scss
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $helveticaNeue;
   color: $darkerGray;
   font-weight: bold;
-  
+
   line-height: 1.7;
   margin: 1em 0 15px;
   padding: 0;
@@ -43,23 +43,23 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.4;
   }
 }
-  
-h1 {  
+
+h1 {
   font-size: 30px;
   a {
     color: inherit;
   }
 }
 
-h2 {  
+h2 {
   font-size: 24px;
 }
 
-h3 {  
+h3 {
   font-size: 20px;
 }
 
-h4 {  
+h4 {
   font-size: 18px;
   color: $gray;
 }
@@ -152,7 +152,7 @@ img {
 .masthead {
   padding: 20px 0;
   border-bottom: 1px solid $lightGray;
-  
+
   @include mobile {
     text-align: center;
   }
@@ -186,20 +186,33 @@ img {
 }
 
 .site-name {
+  padding:0;
+  vertical-align: baseline;
+  font:inherit;
+  font-size: 30px;
+    
   margin: 0;
   color: $darkGray;
   cursor: pointer;
-  font-family: $helveticaNeue; 
+  font-family: $helveticaNeue;
   font-weight: 300;
   font-size: 28px;
   letter-spacing: 1px;
+
+  a {
+    color: inherit;
+  }
+
+  @include mobile {
+    line-height: 1.4;
+  }
 }
 
 .site-description {
   margin: -5px 0 0 0;
   color: $gray;
   font-size: 16px;
-  
+
   @include mobile {
     margin: 3px 0;
   }
@@ -208,9 +221,9 @@ img {
 nav {
   float: right;
   margin-top: 23px; // @TODO: Vertically middle align
-  font-family: $helveticaNeue; 
+  font-family: $helveticaNeue;
   font-size: 18px;
-  
+
   @include mobile {
     float: none;
     margin-top: 9px;
@@ -246,7 +259,7 @@ nav {
   border-bottom: none;
 }
 
-.post { 
+.post {
   blockquote {
     margin: 1.8em .8em;
     border-left: 2px solid $gray;


### PR DESCRIPTION
While HTML5 allows for multiple h1 tags within structural tags, most screen readers, browsers and other tools (eg search engines) treat them all as top-level elements.

I've proposed to edit Jekyll Now to only use H1 headings on the **site name on the home page**, and the on the **page titles for other pages**. I've also edited the `style.scss` file to ensure the theme styling remains as was on updated tags.

When using Jekyll Now as a blogging platform, I believe this'll help with SEO as well as improve HTML5 validity.
