### PR TITLE
Comment with better explanation for disqus configuration flag.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ footer-links:
   twitter: jekyllrb
   stackoverflow: # your stackoverflow profile, e.g. "users/50476/bart-kiers"
 
-# Your disqus shortname, entering this will enable commenting on posts
+# Your website's shortname defined on Disqus. Entering this will enable commenting on posts.
 disqus: 
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking


### PR DESCRIPTION
HI!

Taking into account that someone has never used Disqus before, your comment may be a little ambiguous. For example yesterday I wrote my Disqus username instead of my website's shortname, because I didn't understand word **shortname** correctly. This small addition: **website's shortname** would help me a lot.