### PR TITLE
Fix to facilitate old LinkedIn URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ footer-links:
   flickr: 
   github: barryclark/jekyll-now
   instagram: 
-  linkedin: 
+  linkedin: # please copy the full URL of your linkedIn public profile
   pinterest: 
   rss: # just type anything here for a working RSS icon, make sure you set the "url" above!
   twitter: jekyllrb

--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -4,7 +4,7 @@
           {% if site.footer-links.flickr %}<a href="http://flickr.com/{{ site.footer-links.flickr }}">{% include svg-icons/flickr.html %}</a>{% endif %}
           {% if site.footer-links.github %}<a href="http://github.com/{{ site.footer-links.github }}">{% include svg-icons/github.html %}</a>{% endif %}
           {% if site.footer-links.instagram %}<a href="http://instagram.com/{{ site.footer-links.instagram }}">{% include svg-icons/instagram.html %}</a>{% endif %}
-          {% if site.footer-links.linkedin %}<a href="http://linkedin.com/in/{{ site.footer-links.linkedin }}">{% include svg-icons/linkedin.html %}</a>{% endif %}
+          {% if site.footer-links.linkedin %}<a href="{{ site.footer-links.linkedin }}">{% include svg-icons/linkedin.html %}</a>{% endif %}
           {% if site.footer-links.pinterest %}<a href="http://pinterest.com/{{ site.footer-links.pinterest }}">{% include svg-icons/pinterest.html %}</a>{% endif %}
           {% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml">{% include svg-icons/rss.html %}</a>{% endif %}
           {% if site.footer-links.twitter %}<a href="http://twitter.com/{{ site.footer-links.twitter }}">{% include svg-icons/twitter.html %}</a>{% endif %}


### PR DESCRIPTION
Some people still have their LinkedIn URL in the old fashion.
That is, instead of having a username-based URL i.e `http://linkedin.com/in/username`, their url is still `http://linkedin.com/pub/firstname-lastname/some-random-character/etc`

For example: `https://www.linkedin.com/pub/greg-street/7/644/b35` or 
my old linkedin url before I modify it: `https://www.linkedin.com/pub/fadil-sutomo/10/8aa/a5b`

In summary, the current format of simply supplying LinkedIn username might not work for some people