### PR TITLE
use github flavoured markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,9 @@ markdown: kramdown
 highlighter: pygments
 permalink: /:title/
 
+kramdown:
+  input: GFM
+
 # The release of Jekyll Now that you're using
 version: v1.0.0
 


### PR DESCRIPTION
For me the current markdown settings in _config.yml doesn't handle code section ``` and syntax highlight properly. After adding input: GFM, the code section works fine.