### PR TITLE
Adjustments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,9 @@ footer-links:
 # Your disqus shortname, entering this will enable commenting on posts
 disqus: 
 
+# Your Intense Debate account ID, entering this will enable commenting on posts
+intensedebate:
+
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: 
 

--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,9 @@ baseurl: ""
 # !! You don't need to change any of the configuration flags below !!
 #
 
-markdown: kramdown
+markdown: redcarpet
+redcarpet:
+  extensions: [with_toc_data]
 highlighter: pygments
 permalink: /:title/
 

--- a/_includes/intensedebate.html
+++ b/_includes/intensedebate.html
@@ -1,0 +1,12 @@
+{% if site.intensedebate %}
+<div class="comments">
+    <script type="text/javascript">
+        var idcomments_acct = '{{ site.intensedebate }}';
+        var idcomments_post_id;
+        var idcomments_post_url;
+    </script>
+
+    <span id="IDCommentsPostTitle" style="display:none"></span>
+    <script type='text/javascript' src='http://www.intensedebate.com/js/genericCommentWrapperV2.js'></script>
+</div>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,4 +14,5 @@ layout: default
   </div>
 
   {% include disqus.html disqus_identifier=page.disqus_identifier %}
+  {% include intensedebate.html %}
 </article>

--- a/_scss/_highlights.scss
+++ b/_scss/_highlights.scss
@@ -1,161 +1,84 @@
 
-/***********************/
-/* SYNTAX HIGHLIGHTING */
-/***********************/
-
-.highlight { 
-  background-color: $darkerGray;
-  padding: 5px 10px;
-  margin: 20px 0;
+.highlight {
+  background-color: #efefef;
+  padding: 7px 7px 7px 10px;
+  border: 1px solid #ddd;
+  -moz-box-shadow: 3px 3px rgba(0,0,0,0.1);
+  -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
+  box-shadow: 3px 3px rgba(0,0,0,0.1);
+  margin: 20px 0 20px 0;
+  overflow: hidden;
 }
 
-.highlight pre {
-  /* overflow: scroll; Prefer no word wrap? Uncomment this line and comment out the 2 lines below. */
-  word-break: break-all;
-  word-wrap: break-word;
-}
- 
 code {
-  font-family: 'Courier', monospace;
-  font-size: 14px;
-  color: #999
+  font-family:'Bitstream Vera Sans Mono','Courier', monospace;
 }
- 
-// Solarized Light Pygments 
-// Thanks https://gist.github.com/edwardhotchkiss/2005058
-/* Comment */
-.highlight .c, .highlight .c1 { color: #586E75 }
-/* Error */
-.highlight .err { color: #93A1A1 }
-/* Generic */
-.highlight .g { color: #93A1A1 }
-/* Keyword */
-.highlight .k { color: #859900 }
-/* Literal */
-.highlight .l { color: #93A1A1 }
-/* Name */
-.highlight .n { color: #93A1A1 }
-/* Operator */
-.highlight .o { color: #859900 }
-/* Other */
-.highlight .x { color: #CB4B16 }
-/* Punctuation */
-.highlight .p { color: #93A1A1 }
-/* Comment.Multiline */
-.highlight .cm { color: #586E75 }
-/* Comment.Preproc */
-.highlight .cp { color: #859900 }
-/* Comment.Single */
-.highlight .c1 { color: #586E75 }
-/* Comment.Special */
-.highlight .cs { color: #859900 }
-/* Generic.Deleted */
-.highlight .gd { color: #2AA198 }
-/* Generic.Emph */
-.highlight .ge { color: #93A1A1; font-style: italic }
-/* Generic.Error */
-.highlight .gr { color: #DC322F }
-/* Generic.Heading */
-.highlight .gh { color: #CB4B16 }
-/* Generic.Inserted */
-.highlight .gi { color: #859900 }
-/* Generic.Output */
-.highlight .go { color: #93A1A1 }
-/* Generic.Prompt */
-.highlight .gp { color: #93A1A1 }
-/* Generic.Strong */
-.highlight .gs { color: #93A1A1; font-weight: bold }
-/* Generic.Subheading */
-.highlight .gu { color: #CB4B16 }
-/* Generic.Traceback */
-.highlight .gt { color: #93A1A1 }
-/* Keyword.Constant */
-.highlight .kc { color: #CB4B16 }
-/* Keyword.Declaration */
-.highlight .kd { color: #268BD2 }
-/* Keyword.Namespace */
-.highlight .kn { color: #859900 }
-/* Keyword.Pseudo */
-.highlight .kp { color: #859900 }
-/* Keyword.Reserved */
-.highlight .kr { color: #268BD2 }
-/* Keyword.Type */
-.highlight .kt { color: #DC322F }
-/* Literal.Date */
-.highlight .ld { color: #93A1A1 }
-/* Literal.Number */
-.highlight .m { color: #2AA198 }
-/* Literal.String */
-.highlight .s { color: #2AA198 }
-/* Name.Attribute */
-.highlight .na { color: #93A1A1 }
-/* Name.Builtin */
-.highlight .nb { color: #B58900 }
-/* Name.Class */
-.highlight .nc { color: #268BD2 }
-/* Name.Constant */
-.highlight .no { color: #CB4B16 }
-/* Name.Decorator */
-.highlight .nd { color: #268BD2 }
-/* Name.Entity */
-.highlight .ni { color: #CB4B16 }
-/* Name.Exception */
-.highlight .ne { color: #CB4B16 }
-/* Name.Function */
-.highlight .nf { color: #268BD2 }
-/* Name.Label */
-.highlight .nl { color: #93A1A1 }
-/* Name.Namespace */
-.highlight .nn { color: #93A1A1 }
-/* Name.Other */
-.highlight .nx { color: #555 }
-/* Name.Property */
-.highlight .py { color: #93A1A1 }
-/* Name.Tag */
-.highlight .nt { color: #268BD2 }
-/* Name.Variable */
-.highlight .nv { color: #268BD2 }
-/* Operator.Word */
-.highlight .ow { color: #859900 }
-/* Text.Whitespace */
-.highlight .w { color: #93A1A1 }
-/* Literal.Number.Float */
-.highlight .mf { color: #2AA198 }
-/* Literal.Number.Hex */
-.highlight .mh { color: #2AA198 }
-/* Literal.Number.Integer */
-.highlight .mi { color: #2AA198 }
-/* Literal.Number.Oct */
-.highlight .mo { color: #2AA198 }
-/* Literal.String.Backtick */
-.highlight .sb { color: #586E75 }
-/* Literal.String.Char */
-.highlight .sc { color: #2AA198 }
-/* Literal.String.Doc */
-.highlight .sd { color: #93A1A1 }
-/* Literal.String.Double */
-.highlight .s2 { color: #2AA198 }
-/* Literal.String.Escape */
-.highlight .se { color: #CB4B16 }
-/* Literal.String.Heredoc */
-.highlight .sh { color: #93A1A1 }
-/* Literal.String.Interpol */
-.highlight .si { color: #2AA198 }
-/* Literal.String.Other */
-.highlight .sx { color: #2AA198 }
-/* Literal.String.Regex */
-.highlight .sr { color: #DC322F }
-/* Literal.String.Single */
-.highlight .s1 { color: #2AA198 }
-/* Literal.String.Symbol */
-.highlight .ss { color: #2AA198 }
-/* Name.Builtin.Pseudo */
-.highlight .bp { color: #268BD2 }
-/* Name.Variable.Class */
-.highlight .vc { color: #268BD2 }
-/* Name.Variable.Global */
-.highlight .vg { color: #268BD2 }
-/* Name.Variable.Instance */
-.highlight .vi { color: #268BD2 }
-/* Literal.Number.Integer.Long */
-.highlight .il { color: #2AA198 }
+
+.highlight .c { color: #586E75 } /* Comment */
+.highlight .err { color: #93A1A1 } /* Error */
+.highlight .g { color: #93A1A1 } /* Generic */
+.highlight .k { color: #859900 } /* Keyword */
+.highlight .l { color: #93A1A1 } /* Literal */
+.highlight .n { color: #93A1A1 } /* Name */
+.highlight .o { color: #859900 } /* Operator */
+.highlight .x { color: #CB4B16 } /* Other */
+.highlight .p { color: #93A1A1 } /* Punctuation */
+.highlight .cm { color: #586E75 } /* Comment.Multiline */
+.highlight .cp { color: #859900 } /* Comment.Preproc */
+.highlight .c1 { color: #586E75 } /* Comment.Single */
+.highlight .cs { color: #859900 } /* Comment.Special */
+.highlight .gd { color: #2AA198 } /* Generic.Deleted */
+.highlight .ge { color: #93A1A1; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #DC322F } /* Generic.Error */
+.highlight .gh { color: #CB4B16 } /* Generic.Heading */
+.highlight .gi { color: #859900 } /* Generic.Inserted */
+.highlight .go { color: #93A1A1 } /* Generic.Output */
+.highlight .gp { color: #93A1A1 } /* Generic.Prompt */
+.highlight .gs { color: #93A1A1; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #CB4B16 } /* Generic.Subheading */
+.highlight .gt { color: #93A1A1 } /* Generic.Traceback */
+.highlight .kc { color: #CB4B16 } /* Keyword.Constant */
+.highlight .kd { color: #268BD2 } /* Keyword.Declaration */
+.highlight .kn { color: #859900 } /* Keyword.Namespace */
+.highlight .kp { color: #859900 } /* Keyword.Pseudo */
+.highlight .kr { color: #268BD2 } /* Keyword.Reserved */
+.highlight .kt { color: #DC322F } /* Keyword.Type */
+.highlight .ld { color: #93A1A1 } /* Literal.Date */
+.highlight .m { color: #2AA198 } /* Literal.Number */
+.highlight .s { color: #2AA198 } /* Literal.String */
+.highlight .na { color: #93A1A1 } /* Name.Attribute */
+.highlight .nb { color: #B58900 } /* Name.Builtin */
+.highlight .nc { color: #268BD2 } /* Name.Class */
+.highlight .no { color: #CB4B16 } /* Name.Constant */
+.highlight .nd { color: #268BD2 } /* Name.Decorator */
+.highlight .ni { color: #CB4B16 } /* Name.Entity */
+.highlight .ne { color: #CB4B16 } /* Name.Exception */
+.highlight .nf { color: #268BD2 } /* Name.Function */
+.highlight .nl { color: #93A1A1 } /* Name.Label */
+.highlight .nn { color: #93A1A1 } /* Name.Namespace */
+.highlight .nx { color: #555 } /* Name.Other */
+.highlight .py { color: #93A1A1 } /* Name.Property */
+.highlight .nt { color: #268BD2 } /* Name.Tag */
+.highlight .nv { color: #268BD2 } /* Name.Variable */
+.highlight .ow { color: #859900 } /* Operator.Word */
+.highlight .w { color: #93A1A1 } /* Text.Whitespace */
+.highlight .mf { color: #2AA198 } /* Literal.Number.Float */
+.highlight .mh { color: #2AA198 } /* Literal.Number.Hex */
+.highlight .mi { color: #2AA198 } /* Literal.Number.Integer */
+.highlight .mo { color: #2AA198 } /* Literal.Number.Oct */
+.highlight .sb { color: #586E75 } /* Literal.String.Backtick */
+.highlight .sc { color: #2AA198 } /* Literal.String.Char */
+.highlight .sd { color: #93A1A1 } /* Literal.String.Doc */
+.highlight .s2 { color: #2AA198 } /* Literal.String.Double */
+.highlight .se { color: #CB4B16 } /* Literal.String.Escape */
+.highlight .sh { color: #93A1A1 } /* Literal.String.Heredoc */
+.highlight .si { color: #2AA198 } /* Literal.String.Interpol */
+.highlight .sx { color: #2AA198 } /* Literal.String.Other */
+.highlight .sr { color: #DC322F } /* Literal.String.Regex */
+.highlight .s1 { color: #2AA198 } /* Literal.String.Single */
+.highlight .ss { color: #2AA198 } /* Literal.String.Symbol */
+.highlight .bp { color: #268BD2 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #268BD2 } /* Name.Variable.Class */
+.highlight .vg { color: #268BD2 } /* Name.Variable.Global */
+.highlight .vi { color: #268BD2 } /* Name.Variable.Instance */
+.highlight .il { color: #2AA198 } /* Literal.Number.Integer.Long */

--- a/_scss/_highlights.scss
+++ b/_scss/_highlights.scss
@@ -7,7 +7,7 @@
   -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
   box-shadow: 3px 3px rgba(0,0,0,0.1);
   margin: 20px 0 20px 0;
-  overflow: hidden;
+  overflow: scroll;
 }
 
 code {


### PR DESCRIPTION
Hey @barryclark!  As discussed on Twitter, here are some changes I included in [my version of Jekyll Now](https://github.com/rnicholus/you-dont-need-jquery) in my ["You Don't Need jQuery" blog](http://blog.garstasio.com/you-dont-need-jquery/). 

Quick summary:
- switched to redcarpet for markdown
- IDs added to section headlines for easy TOC generation
- better syntax highlighting (IMHO)
- long code blocks are scrollable
- optionally use Intense Debate for comments instead of disqus

Let me know if you want me to make any changes, assuming you're interested in any of this.  

Thanks again for Jekyll Now.  Really an amazingly easy way to get a blog up an running on Github Pages.