### PR TITLE
Resolves #72 by overriding an img style

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -110,6 +110,11 @@ img {
   max-width: 100%;
 }
 
+// Fixes images in popup boxes from Google Translate
+.gmnoprint img {
+  max-width: none;
+}
+
 .date {
   font-style: italic;
   color: $gray;


### PR DESCRIPTION
This commit fixes the issue where Google Translate bubbles were not displaying correctly. The issue is that img {max-width: 100%} was breaking the images in the bubble since everything inside the bubble is absolutely positioned (therefore 0px width for images).

I've added a CSS selector to override the img selector above it in cases where the Google Translate bubbles pop up. The best selector I could create was using the .gmnoprint class as it's one of the main containers of the images inside a Google Translate bubble.