### PR TITLE
vertically middle align header with flexbox

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -155,16 +155,18 @@ img {
 }
 
 .masthead {
+  display: flex;
+  align-items: center;
   padding: 20px 0;
   border-bottom: 1px solid $lightGray;
 
   @include mobile {
+    display: block;
     text-align: center;
   }
 }
 
 .site-avatar {
-  float: left;
   width: 70px;
   height: 70px;
   margin-right: 15px;
@@ -181,7 +183,8 @@ img {
 }
 
 .site-info {
-  float: left;
+  flex: 1; // stretches to fill all space (pushing nav to right)
+  align-self: flex-start;
 
   @include mobile {
     float: none;
@@ -211,8 +214,6 @@ img {
 }
 
 nav {
-  float: right;
-  margin-top: 23px; // @TODO: Vertically middle align
   font-family: $helveticaNeue;
   font-size: 18px;
 


### PR DESCRIPTION
Noticed the "TODO: vertically middle align" and gave it a shot with flexbox. Rendering is unchanged on mobile, a few pixels different in full-size, as you can (or can't!) see:

Before:
![sans-flex](https://cloud.githubusercontent.com/assets/1269436/6653164/01c7efb4-ca87-11e4-9d6e-1e57e88e3c2e.png)

After:
![flex](https://cloud.githubusercontent.com/assets/1269436/6653157/db8f0418-ca86-11e4-9c72-fd757686c649.png)

(sorry, forgot to turn off red screen overlay when taking the pictures - colors *are* unchanged)

Elements in the flex container don't float. I guess there are several ways to pin the ```nav``` to the right; I opted for ```flex: 1``` on ```.site-info``` which is short for ```flex-grow: 1``` and basically means it grows to fill the empty space of the flex container. Thus pushing the ```nav``` to the right. To me, it's a clean solution but perhaps not the semantically optimal one. Open for suggestions!