### PR TITLE
About page was not pulling header info set in _config

### DIFF
--- a/about.md
+++ b/about.md
@@ -13,3 +13,4 @@ A place to include any other types of information that you'd like to include abo
 ### Contact me
 
 [email@domain.com](mailto:email@domain.com)
+![_config.yml]({{ site.baseurl }}/images/config.png)


### PR DESCRIPTION
I added ```![_config.yml]({{ site.baseurl }}/images/config.png)``` to the bottom to get the header info