### PR TITLE
Add quotes as the url default value

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,12 +21,12 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: barryclark/jekyll-now
+  github: boubz
   instagram:
   linkedin:
   pinterest:
   rss: # just type anything here for a working RSS icon, make sure you set the "url" above!
-  twitter: jekyllrb
+  twitter: 
   stackoverflow: # your stackoverflow profile, e.g. "users/50476/bart-kiers"
   youtube: # channel/<your_long_string> or user/<user-name>
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ google_analytics:
 
 # Your website URL (e.g. "http://barryclark.github.io" or "http://www.barryclark.co")
 # Used for Sitemap.xml and your RSS feed
-url: http://www.barryclark.co
+url: http://www.thomasbrisbout.com
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)

--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,10 @@
 name: Thomas Brisbout
 
 # Short bio or description (displayed in the header)
-description: Web Developer from Somewhere
+description: Web Developer
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
-avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
+avatar: https://avatars0.githubusercontent.com/u/1216408?v=3&s=460
 
 #
 # Flags below are optional

--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ google_analytics:
 
 # Your website URL (e.g. "http://barryclark.github.io" or "http://www.barryclark.co")
 # Used for Sitemap.xml and your RSS feed
-url: ""
+url: http://www.barryclark.co
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 #
 
 # Name of your site (displayed in the header)
-name: Your Name
+name: Thomas Brisbout
 
 # Short bio or description (displayed in the header)
 description: Web Developer from Somewhere

--- a/_config.yml
+++ b/_config.yml
@@ -37,9 +37,9 @@ disqus:
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics:
 
-# Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
+# Your website URL (e.g. "http://barryclark.github.io" or "http://www.barryclark.co")
 # Used for Sitemap.xml and your RSS feed
-url:
+url: ""
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
When putting a website url without quotes, it may break the build
performed by github