### PR TITLE
Added filterable tags to Jekyll Now. 

### DIFF
--- a/_posts/2014-3-3-Hello-World.md
+++ b/_posts/2014-3-3-Hello-World.md
@@ -1,6 +1,10 @@
 ---
 layout: post
 title: You're up and running!
+tags:
+- Hello
+- world
+- jekyll-now
 ---
 
 Next you can update your site name, avatar and other options using the _config.yml file in the root of your repository (shown below).

--- a/_sass/_tags.scss
+++ b/_sass/_tags.scss
@@ -1,0 +1,74 @@
+$tagColour: lightblue;
+
+@mixin tag-button($colour)
+{
+    border-radius: 15px;
+    background: $colour;
+    height: 30px; 
+    vertical-align: middle;
+    text-align: center;   
+}
+
+@mixin selected-button()
+{
+    border-radius: 15px;
+    background: darkblue;
+    color: white;
+    height: 35px; 
+    vertical-align: middle;
+}
+
+.posts
+{
+    width: 78%;
+    display: inline-block;
+}
+
+#tag-pane
+{
+    width: 20%;
+    vertical-align: top;
+    display: inline-block;
+    margin-top: 30px;
+    
+    div.tag-selectors
+    {
+        p.tag-selector
+        {
+            text-align: center;   
+            @include tag-button($tagColour);
+        }
+
+        p.selected
+        {
+            @include selected-button();
+        }
+    }
+    
+}
+
+div.tags
+{
+    margin-top: 10px;
+    height: 30px;
+}
+
+p.filter-caption
+{
+    @include tag-button(yellow);
+}
+
+div.tag
+{
+    display: inline;
+    padding: 5px;
+    @include tag-button($tagColour);
+    width: 50px;
+}
+
+$clearWritingColour: black;
+
+p.clear-tags
+{
+    @include tag-button(lightgreen);
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,170 @@ layout: default
       </div>
 
       <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
+      
+      <div class="tags">
+        {% for tag in post.tags %}
+          <div class="tag {{tag}}">{{tag}}</div>
+        {% endfor %}
+    </div>
+        
     </article>
   {% endfor %}
 </div>
+
+<div id="tag-pane">
+<p class="filter-caption">
+    Filter by tag:
+    </p>
+</div>
+
+	<script>
+		var getTagNamesFromPost = function(post){
+			var tags = post.querySelectorAll(".tag");
+			var tagNames = [];
+				for(var i = 0; i < tags.length; i++)
+				{
+					var tag = tags[i];
+					var tagName = tag.classList[1];
+					tagNames.push(tagName);
+				}
+			return tagNames;
+		}
+		
+		var getTagsAndPosts = function(posts){
+			var allTagNames = [];
+			var tagsAndPosts = {};
+			
+			for(var i = 0; i < posts.length; i++)
+			{
+				var post = posts[i];
+				
+				var tagNames = getTagNamesFromPost(post);
+				for(var j = 0; j < tagNames.length; j++)
+				{
+					var tagName = tagNames[j];
+					allTagNames.push(tagName)
+					
+					if(tagsAndPosts[tagName] === undefined)
+						tagsAndPosts[tagName] = [i];
+					else
+						tagsAndPosts[tagName].push(i);
+				}
+			}
+			
+			return tagsAndPosts;
+		};
+		var addClass = function(element, className){
+			if (element.classList)
+				element.classList.add(className);
+			else
+				element.className += ' ' + className;
+		};
+		
+		var hideAllPosts = function(posts){
+			for(var i = 0; i < posts.length; i++)
+			{
+				posts[i].style.display = 'none';
+			}
+		};
+		
+		var displayPosts = function(allPosts, postsToDisplay){
+			hideAllPosts(allPosts);
+			
+			for(var i = 0; i < postsToDisplay.length; i++)
+			{
+				var indexToShow = postsToDisplay[i];
+				allPosts[indexToShow].style.display = '';
+			}
+		};
+		
+		var hasClass = function(element, cls) {
+			return (' ' + element.className + ' ').indexOf(' ' + cls + ' ') > -1;
+		};
+		
+		var removeClass = function(element, className){
+			element.className = element.className.replace(className, "");
+		};
+		
+		var removeSelectedClassFromAllTags = function(tagsAndTagSelectorElements, selectedClass){
+			for(var tagName in tagsAndTagSelectorElements)
+			{
+				if(tagsAndTagSelectorElements.hasOwnProperty(tagName))
+				{
+					removeClass(tagsAndTagSelectorElements[tagName], selectedClass);
+				}
+			}
+		};
+		
+		document.addEventListener("DOMContentLoaded", function(event) { 
+			var posts = document.querySelectorAll('.post');
+			var tagsAndPosts = getTagsAndPosts(posts);
+			
+			var divElement = document.createElement("div");
+			addClass(divElement, "tag-selectors");
+			
+			var clearText = "clear";
+			var clearTagsElement = document.createElement("p");
+			addClass(clearTagsElement, "clear-tags");
+			clearTagsElement.innerText = clearText;
+			divElement.appendChild(clearTagsElement);
+			
+			var selectedClass = "selected";
+			
+			var tagsAndTagSelectorElements = {}
+			tagsAndTagSelectorElements[clearText] = clearTagsElement;
+			
+			for(var tagName in tagsAndPosts)
+			{
+				if(tagsAndPosts.hasOwnProperty(tagName))
+				{
+					var postsContainingTag = tagsAndPosts[tagName];
+					var numberOfPosts = postsContainingTag.length;
+					var classToAdd = "count-" + numberOfPosts;
+					
+					var tagPElement = document.createElement("p");
+					addClass(tagPElement, "tag-selector");
+					addClass(tagPElement, classToAdd);
+					tagPElement.textContent = tagName;
+					
+					tagsAndTagSelectorElements[tagName] = tagPElement;
+					
+					divElement.appendChild(tagPElement);
+				}
+			}
+			
+			var clearShowing = "showing";
+			
+			for(var tagName in tagsAndTagSelectorElements)
+			{
+				if(tagsAndTagSelectorElements.hasOwnProperty(tagName))
+				{
+					tagsAndTagSelectorElements[tagName]
+						.addEventListener("click", 
+						function(eventObj) {
+							var tagName = eventObj.currentTarget.innerText;
+							
+							removeSelectedClassFromAllTags(tagsAndTagSelectorElements, selectedClass);
+							
+							if(tagName === clearText)
+							{
+								removeClass(clearTagsElement, clearShowing);
+								var allPosts = [];
+								for(var n = 0; n < posts.length; n++)
+									allPosts.push(n);
+								
+								displayPosts(posts, allPosts);
+								return;
+							}
+							addClass(clearTagsElement, clearShowing);
+							addClass(tagsAndTagSelectorElements[tagName], selectedClass);
+							var postsToShow = tagsAndPosts[tagName];
+							displayPosts(posts, postsToShow);
+						});
+				}
+			}
+			
+			var tagPaneElement = document.getElementById("tag-pane");
+			tagPaneElement.appendChild(divElement);
+		});
+	</script>

--- a/style.scss
+++ b/style.scss
@@ -287,3 +287,4 @@ footer {
 // ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
 @import "highlights";
 @import "svg-icons";
+@import "tags";


### PR DESCRIPTION
I'm a big fan of Jekyll Now, cheers for making my blog a lot easier to make! One of the feature's that I want for my blog, is to be able to tag posts and then filter the posts by the tags.

I have implemented this to a standard that i'm happy with and i'm throwing out a pull request in case this is something that would be desirable for the project. 
It's a bit hacky, to simplify the JS the tag names need to be able to be class names. So lower case and hyphens instead of spaces.

Don't mind if it's not merged, but thought i'd release my effort in case it would be wanted.

(Just a warning, I hadn't previously done any ruby before this and my styling skills aren't great. But it works for me!)