### PR TITLE
Exclude CNAME

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,3 +74,4 @@ exclude:
     - Gemfile.lock
     - LICENSE
     - README.md
+    - CNAME


### PR DESCRIPTION
There’s no reason you’d want to be able to access the CNAME file on the
hosted site.