### PR TITLE
Add the Spectral theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can use the [Quick Start](https://github.com/barryclark/jekyll-now#quick-sta
 - [Left](https://github.com/holman/left) by Zach Holman
 - [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) by Michael Rose
 - [Skinny Bones](https://github.com/mmistakes/skinny-bones-jekyll) by Michael Rose
+- [Spectral] (https://github.com/umangraghuvanshi/spectral) by Umang Raghuvanshi
 
 ## Credits
 


### PR DESCRIPTION
The Spectral theme is an open-source Jekyll theme. It is responsive and super easy to use. It also looks awesome, both on Desktop and Mobile devices. This commit adds it to jekyll-now's README.md, the repository from where I got started with Jekyll.