### PR TITLE
Autogenerated tag index, disqus counters and others

### DIFF
--- a/404.md
+++ b/404.md
@@ -3,6 +3,6 @@ layout: page
 title: 404 - Page not found
 ---
 
-Sorry, we can't find that page that you're looking for. You can try take for a look by going [back to the homepage]({{ site.baseurl }}/).
+Sorry, we can't find that page that you're looking for. You can try again by going [back to the homepage]({{ site.baseurl }}/).
 
-[<img src="{{ site.baseurl }}/images/404.jpg" alt="Constructocat by https://github.com/jasoncostello" style="width: 400px;"/>]({{ site.baseurl }}/)
+[<p align="center"><img src="{{ site.baseurl }}/images/404.jpg" alt="Constructocat by https://github.com/jasoncostello" style="width: 300px;"/></p>]({{ site.baseurl }}/)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ In a few minutes you'll be set up with a minimal, responsive blog like the one b
 
 ![Jekyll Now Theme Screenshot](/images/jekyll-now-theme-screenshot.jpg "Jekyll Now Theme Screenshot")
 
+## TODO
+
+* Wiki: Feed.
+* Wiki: Disqus.
+* Wiki: how put favicon.
+* Wiki: Copy tags.
+* Code: Check social buttons - email, facebook, github, bitbucket, linkedin, rss, twitter, tumblr, youtube, g+.
+
 ## Quick Start
 
 ### Step 1) Fork Jekyll Now to your User Repository

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ name: Your Name
 description: Web Developer from Somewhere
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
-avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
+avatar: /images/jekyll-logo.png
 
 #
 # Flags below are optional

--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,7 @@ sass:
 
 # Use the following plug-ins
 gems:
+  - jekyll-redirect-from  # Just use 'redirect_from: "/foo"' on the YAML header
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
 
 # Exclude these files from your production _site

--- a/_includes/disqus_counter.html
+++ b/_includes/disqus_counter.html
@@ -1,0 +1,15 @@
+{% if site.disqus %}
+    <script type="text/javascript">
+
+      /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+      var disqus_shortname = '{{ site.disqus }}';
+
+      /* * * DON'T EDIT BELOW THIS LINE * * */
+      (function () {
+        var s = document.createElement('script'); s.async = true;
+        s.type = 'text/javascript';
+        s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+      }());
+    </script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
+    <link rel="icon" type="image/x-icon" href="http://jekyllrb.com/favicon.ico">
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
   </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,5 +47,7 @@
     </div>
 
     {% include analytics.html %}
+
+    {% include disqus_counter.html %}
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,18 @@ layout: default
 <article class="post">
   <h1>{{ page.title }}</h1>
 
+  <small>
+    {% if site.disqus %}
+        <a href="{{ post.url }}#disqus_thread"></a>
+    {% endif %}
+    {% if page.tags.size > 0 %}
+        Tags: 
+      {% for tag in page.tags %}
+        <a href="/tag/{{ tag }}">{{ tag }} </a> 
+      {% endfor %}
+    {% endif %} 
+   </small>
+
   <div class="entry">
     {{ content }}
   </div>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+
+<!-- Source and Idea from: http://charliepark.org/tags-in-jekyll/ -->
+<h2 class="post_title">{{page.title}}</h2>
+<ul>
+    {% for post in site.posts %}
+        {% for tag in post.tags %}
+            {% if tag == page.tag %}
+                <article class="post">
+
+                      <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+                      <small>
+                        {% if site.disqus %}
+                            <a href="{{ post.url }}#disqus_thread"></a>
+                        {% endif %}
+                        {% if post.tags.size > 0 %}
+                            Tags: 
+                          {% for tag in post.tags %}
+                            <a href="/tag/{{ tag }}">{{ tag }} </a> 
+                          {% endfor %}
+                        {% endif %} 
+                       </small>
+
+                      <div class="entry">
+                        {% if post.summary %}
+                            {{ post.summary }}
+                        {% else %}
+                            {{ post.excerpt}}
+                        {% endif %}  
+                      </div>
+                      <br/>
+                      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
+                    </article>
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+</ul>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -9,30 +9,29 @@ layout: default
         {% for tag in post.tags %}
             {% if tag == page.tag %}
                 <article class="post">
+                  <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+                  <small>
+                    {% if site.disqus %}
+                        <a href="{{ post.url }}#disqus_thread"></a>
+                    {% endif %}
+                    {% if post.tags.size > 0 %}
+                        Tags: 
+                      {% for tag in post.tags %}
+                        <a href="/tag/{{ tag }}">{{ tag }} </a> 
+                      {% endfor %}
+                    {% endif %} 
+                   </small>
 
-                      <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
-                      <small>
-                        {% if site.disqus %}
-                            <a href="{{ post.url }}#disqus_thread"></a>
-                        {% endif %}
-                        {% if post.tags.size > 0 %}
-                            Tags: 
-                          {% for tag in post.tags %}
-                            <a href="/tag/{{ tag }}">{{ tag }} </a> 
-                          {% endfor %}
-                        {% endif %} 
-                       </small>
-
-                      <div class="entry">
-                        {% if post.summary %}
-                            {{ post.summary }}
-                        {% else %}
-                            {{ post.excerpt}}
-                        {% endif %}  
-                      </div>
-                      <br/>
-                      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-                    </article>
+                  <div class="entry">
+                    {% if post.summary %}
+                        {{ post.summary }}
+                    {% else %}
+                        {{ post.excerpt}}
+                    {% endif %}  
+                  </div>
+                  <br>
+                  <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
+              </article>
             {% endif %}
         {% endfor %}
     {% endfor %}

--- a/_plugins/tag_generator.rb
+++ b/_plugins/tag_generator.rb
@@ -1,0 +1,39 @@
+# Source and Idea from: http://charliepark.org/tags-in-jekyll/
+
+module Jekyll
+
+  class TagIndex < Page    
+    def initialize(site, base, dir, tag)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'tag_index.html')
+      self.data['tag'] = tag
+      self.data['title'] = "Posts Tagged with &ldquo;"+tag+"&rdquo;"
+    end
+  end
+
+  class TagGenerator < Generator
+    safe true
+    
+    def generate(site)
+      if site.layouts.key? 'tag_index'
+        dir = 'tag'
+        site.tags.keys.each do |tag|
+          write_tag_index(site, File.join(dir, tag), tag)
+        end
+      end
+    end
+  
+    def write_tag_index(site, dir, tag)
+      index = TagIndex.new(site, site.source, dir, tag)
+      index.render(site.layouts, site.site_payload)
+      index.write(site.dest)
+      site.pages << index
+    end
+  end
+
+end

--- a/_posts/2014-3-3-Hello-World.md
+++ b/_posts/2014-3-3-Hello-World.md
@@ -1,6 +1,9 @@
 ---
 layout: post
 title: You're up and running!
+summary: Enter this post to know how configure your blog
+tags:
+- welcome-tag
 ---
 
 Next you can update your site name, avatar and other options using the _config.yml file in the root of your repository (shown below).

--- a/index.html
+++ b/index.html
@@ -7,11 +7,26 @@ layout: default
     <article class="post">
 
       <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+      <small>
+        {% if site.disqus %}
+            <a href="{{ post.url }}#disqus_thread"></a>
+        {% endif %}
+        {% if post.tags.size > 0 %}
+            Tags: 
+          {% for tag in post.tags %}
+            <a href="/tag/{{ tag }}">{{ tag }} </a> 
+          {% endfor %}
+        {% endif %} 
+       </small>
 
       <div class="entry">
-        {{ post.excerpt }}
+        {% if post.summary %}
+            {{ post.summary }}
+        {% else %}
+            {{ post.excerpt}}
+        {% endif %}  
       </div>
-
+      <br/>
       <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
     </article>
   {% endfor %}


### PR DESCRIPTION
Hello everybody, I just loved so much Jekyll-now that I have to help it out with something quite usefull and easy to use and set-up:

# Autogenerated tags

I added a plugin to autogenerate tag pages for differents tags, all you have to do is add

```
tags:
- some-tag
```

to the YAML head and the tags will appear in the main page and in the post page so if you click it, it will send you to a page with all the post under that tag. The source code of this plugin is not my own so I added a comment in the rb file pointing to the original source code.

# Disqus comment counter

If you add your disqus account the post will show in the main page how many comments the post have. I noticed that disqus take some time to update the counter... but it works :)

# Others

* 404.md had some issues with the size of the img, it made the body wider.
* Now the avatar can be set from /image/ folder.
* Added jekyll-redirect-from, but not implemented.
* Post show excerpt in the main page, but now if you set summary in the YAML header it shows the summary instead.
* Update post.html and index.html to work with the changes made.


Hope it helps :D I am also thinking in writing some tutorials in the wiki, hope that is okay because when I downloaded this repo I didn't know how to use it, it ended being quite easy but I had to waste time googling when I could have readed some tutorials here.

Also, I'm from Chile and some of my friends would like to use this too but they don't know any english, it's okay if I create a branch or a new repo in my account with everything translated?