### PR TITLE
Remove reference to 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Edit `/_posts/2014-3-3-Hello-World.md` to publish your first blog post. This [Ma
 1. Install Jekyll and plug-ins in one fell swoop. `gem install github-pages` This mirrors the plug-ins used by GitHub Pages on your local machine including Jekyll, Sass, etc.
 2. Clone down your fork `git clone git@github.com:yourusername/yourusername.github.io.git`
 3. Serve the site and watch for markup/sass changes `jekyll serve`
-4. View your website at http://0.0.0.0:4000
+4. View your website at http://127.0.0.1:4000/
 5. Commit any changes and push everything to the master branch of your GitHub user repository. GitHub Pages will then rebuild and serve your website.
 
 ## Moar!


### PR DESCRIPTION
`0.0.0.0` doesn't really make much sense, and in fact shouldn't even work at all. It's pretty strange that it does work given [RFC1122 explicitly disallows usage of the 0 network](rfc1122):  :stuck_out_tongue: 

```
            We now summarize the important special cases for Class A, B,
            and C IP addresses, using the following notation for an IP
            address:

                { <Network-number>, <Host-number> }
...
            (a)  { 0, 0 }

                 This host on this network.  MUST NOT be sent, except as
                 a source address as part of an initialization procedure
                 by which the host learns its own IP address.
```

[rfc1122]: https://tools.ietf.org/html/rfc1122#section-3.3.6