### PR TITLE
Add .jekyll-metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site
 .DS_Store
 .jekyll
+.jekyll-metadata
 .bundle
 .sass-cache
 Gemfile


### PR DESCRIPTION
`.jekyll-metadata` is introduced since Jekyll 3.0.

> This helps Jekyll keep track of which files have not been modified since the site was last built, and which files will need to be regenerated on the next build. This file will not be included in the generated site. It’s probably a good idea to add this to your `.gitignore` file.

from http://jekyllrb.com/docs/structure/