### PR TITLE
Improve support for Jekyll 3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,12 +53,12 @@ baseurl: ""
 # !! You don't need to change any of the configuration flags below !!
 #
 
-markdown: redcarpet
-highlighter: pygments
+markdown: kramdown
+highlighter: rouge
 permalink: /:title/
 
 # The release of Jekyll Now that you're using
-version: v1.1.0
+version: v3.0.2
 
 # Set the Sass partials directory, as we're using @imports
 sass:


### PR DESCRIPTION
I'm using this template as part of a GitHub lesson and stumbled upon email notifications caused by GitHub's [recent upgrade](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0) to Jekyll 3.0 about the syntax highlighter. This pull request is just a few edits in the configuration to improve support for Jekyll 3.0. I'll be using them in my lesson, to prevent learners from getting needless email notifications from GitHub, and I just thought I'd quickly send you a pull request. 

Thanks for the template, by the way! :ok_hand: 