### PR TITLE
Move to Kramdown and Rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,12 +53,20 @@ baseurl: ""
 # !! You don't need to change any of the configuration flags below !!
 #
 
-markdown: redcarpet
-highlighter: pygments
 permalink: /:title/
 
 # The release of Jekyll Now that you're using
 version: v1.1.0
+
+# Jekyll 3 now only supports Kramdown for Markdown
+kramdown:
+  # Use GitHub flavored markdown, including triple backtick fenced code blocks
+  input: GFM
+  # Jekyll 3 and GitHub Pages now only support rouge for syntax highlighting
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    # Use existing pygments syntax highlighting css
+    css_class: 'highlight'
 
 # Set the Sass partials directory, as we're using @imports
 sass:


### PR DESCRIPTION
Jekyll 3 and GitHub Pages have moved to ONLY support Kramdown and Rouge as the Markdown engine and syntax highlighter for Jekyll. See: https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

This commit is a small update to `_config.yml` that enables Jekyll Now to fully support those changes, including maintaining the existing pygments syntax highlighting CSS.
