### PR TITLE
Added twitter:card meta data.

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -3,6 +3,7 @@
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
 
+    <meta name="twitter:card" content="summary" />
     {% if page.excerpt %}
     <meta name="description" content="{{ page.excerpt| strip_html }}" />
     <meta property="og:description" content="{{ page.excerpt| strip_html }}" />


### PR DESCRIPTION
Pages created by jekyll-now don't have `twitter:card` meta data in default.
I added `twitter:card  summary` meta data so that Twitter displays twitter cards on your posts.


Thanks