### PR TITLE
Adding ld-json schema for a blog site

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,18 @@
 ---
 layout: default
 ---
+<script type="application/ld+json">{
+"@context": "http://schema.org",
+"@type": "Blog",
+"name": "{{ site.name }}",
+"url": "{{ site.url }}",
+"description": "{{ site.desciption }}",
+,
+"publisher": {
+"@type": "{{ site.name }}",
+"name": "{{ site.author }}"
+}
+}</script>
 
 <article class="page">
 


### PR DESCRIPTION
When I used the default page template, tools like Google webmaster and Bing complained that the page did not have a LD-JSON structured markup.

I added the basic fields necessary to make the page more SEO friendly. Hope this would be of use to every one who uses your template.