### PR TITLE
Adding a parameter named "author"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,9 @@
 # Name of your site (displayed in the header)
 name: Your Name
 
+# Name to be used for creating the LD-JSON structured data. Useful when the name of the blog is different from the name of the author.
+author: Your name 
+
 # Short bio or description (displayed in the header)
 description: Web Developer from Somewhere
 


### PR DESCRIPTION
I've added a parameter called "Author". This would be useful when the name of the blog is different from the author's name. It may be of use when a different name is needed to be used when generating the LD-JSON structured data.