### PR TITLE
Updated the schemes in the sample links to HTTPS instead of HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In a few minutes you'll be set up with a minimal, responsive blog like the one b
 
 Fork this repo, then rename the repository to yourgithubusername.github.io.
 
-Your Jekyll blog will often be viewable immediately at <http://yourgithubusername.github.io> (if it's not, you can often force it to build by completing step 2)
+Your Jekyll blog will often be viewable immediately at <https://yourgithubusername.github.io> (if it's not, you can often force it to build by completing step 2)
 
 ![Step 1](/images/step1.gif "Step 1")
 
@@ -30,7 +30,7 @@ Your Jekyll blog will often be viewable immediately at <http://yourgithubusernam
 
 Enter your site name, description, avatar and many other options by editing the _config.yml file. You can easily turn on Google Analytics tracking, Disqus commenting and social icons here too.
 
-Making a change to _config.yml (or any file in your repository) will force GitHub Pages to rebuild your site with jekyll. Your rebuilt site will be viewable a few seconds later at <http://yourgithubusername.github.io> - if not, give it ten minutes as GitHub suggests and it'll appear soon
+Making a change to _config.yml (or any file in your repository) will force GitHub Pages to rebuild your site with jekyll. Your rebuilt site will be viewable a few seconds later at <https://yourgithubusername.github.io> - if not, give it ten minutes as GitHub suggests and it'll appear soon
 
 > There are 3 different ways that you can make changes to your blog's files:
 


### PR DESCRIPTION
HTTPS is now enforced for all URLs using github.io, e.g. userName.github.io must use https://userName.github.io You can no longer use HTTP:// as mentioned at the bottom of this blog post: https://github.com/blog/2186-https-for-github-pages