### PR TITLE
Rename Gems to Plugins in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ sass:
   style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
-gems:
+plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
 


### PR DESCRIPTION
According to Jekyll: `Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.`