### PR TITLE
Fixed issue of syntax highlighting of code blocks causing nested scrollbars

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,13 +1,17 @@
 
 .highlight {
   background-color: #efefef;
-  padding: 7px 7px 7px 10px;
-  border: 1px solid #ddd;
-  -moz-box-shadow: 3px 3px rgba(0,0,0,0.1);
-  -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
-  box-shadow: 3px 3px rgba(0,0,0,0.1);
-  margin: 20px 0 20px 0;
-  overflow: scroll;
+  //border: 1px solid #ddd;
+  //-moz-box-shadow: 3px 3px rgba(0,0,0,0.1);
+  //-webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
+  //box-shadow: 3px 3px rgba(0,0,0,0.1);
+  margin: 0px 0 20px 0;
+  overflow: auto;
+}
+
+pre.highlight {
+  padding: 10px 0.5em;
+  margin-bottom: 0px;
 }
 
 code {


### PR DESCRIPTION
When I set up my blog with your fork, anytime I created code blocks using the triple backtick syntax, I would get a double nested set of empty scrollbars. This would occur even when there was nothing to scroll. This fixes that issue as far as I can tell.