### PR TITLE
#1025 | Fix for nested code block issue

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-.highlight {
+pre.highlight {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;


### PR DESCRIPTION
The parsers are building a code block like `<div class='highlight><pre class='highlight'>`. With the previous CSS, both the div and pre were creating a code block which led to having an odd nested code block. With this fix, only the pre is a code block. 