### PR TITLE
Fix jekyll gems deprecation warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ sass:
   style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
-gems:
+plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
 


### PR DESCRIPTION
Using jekyll 3.6.4 I get this warning message when building the site locally:
```
$ jekyll serve --watch
Configuration file: /home/gerard/Documents/blog/_config.yml
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```