### PR TITLE
Changed gems to plugins in _config.yml, gems is deprecated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ sass:
   style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
-gems:
+plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
 


### PR DESCRIPTION
Got this notice during local development:

```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```

Changed `gems` to `plugins` in `_config.yml`, and the notice is gone. Also tested the new configuration with GitHub Pages, it still works with the new name `plugins`.


```
-----BEGIN PGP MESSAGE-----
Comment: Verify on https://keybase.io/verify

owFdUb1LHEEU39MTdUERopdK7gWLQ5C1CYJWxghKQBA0Qb3Cmdt97g7Ozmx2Zj0O
O0WwMCaNIiFgqSkU/AcsRERFsJCzEBuxsrCw0kLBvfOOQKoH773f13u/mmqNhlTH
xWTzxWmqM7GTcHPN2g8sZ2zgo44mvuvJ7M1G/ZDUoD2mQEjNbAQnCplwgUubcnBw
DrkMfBS6zzQJIeYgBiHaVDMp+mDcQ8i46KsM2FLMMDcKyxOQQbl4VEEOUUCIgvro
gJaQCXjkMqEyFoxypAohChyqEQoyCis0MMM4ArVtGTqxGV6wytrmZ48KN6YhJU1S
YiMVNgJMAJl+g1sFn5MuoCIWjB1WgsURXSnQgk9cSdCoNFbmmP/Pfp5pD4aYHo5y
MEpdVF3ANCjNOIe8DGfV20YVXMr2z4llLkdJI9VgtKc+JPvTxYWHzU7/eu3qvvqJ
uprS3Q2zsaXaOVtPGE8Hj1+3Di/3vpxMLe0fLdaOzHcn66+Pb/8+//7Tk/5xljBW
fhazZs320+aId/d+NdubTxenBnfftZ2/fBtvaV1tfAU=
=UOwy
-----END PGP MESSAGE-----
```