### PR TITLE
License date bump

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Barry Clark
+Copyright (c) 2019 Barry Clark
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The last date bump for the license was in 2015, and it is now 2019, so I thought I’d update this.