### PR TITLE
applies code block styling to pre tag

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-.highlight {
+pre {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;

--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-pre {
+.highlight pre {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;


### PR DESCRIPTION
Please, refer to [this issue](https://github.com/barryclark/jekyll-now/issues/1526)