### PR TITLE
Fix small typo with line not wrapping in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It covers:
 ✓ SVG social icons for your footer  
 ✓ 3 http requests, including your avatar  
 
-✘ No installing dependencies
+✘ No installing dependencies  
 ✘ No need to set up local development  
 ✘ No configuring plugins  
 ✘ No need to spend time on theming  


### PR DESCRIPTION
One of the lines was missing two spaces so there wasn't a line break