### PR TITLE
Fix font size and alignment of sub and sup HTML tags

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -51,3 +51,11 @@ table {
 *, *:before, *:after {
   -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
 }
+sub {
+	font-size: smaller;
+	vertical-align: sub;
+}
+sup {
+	font-size: smaller;
+	vertical-align: super;
+}


### PR DESCRIPTION
Currently, the styling applied to the `<sup>` and `<sub>` tags does not format the enclosed text in superscripts and subscripts. In this PR, I apply some CSS styling to both tags so that they are displayed in a manner closer to what is expected of them. The patch was taken from [here](https://github.com/Quuxplusone/blog/commit/60126d4d5a68abd6736690434675095bf1560d74), credit goes to @Quuxplusone.

I believe this fixes #933 and #1112.