### PR TITLE
Update box sizing CSS

### DIFF
--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -46,8 +46,13 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
-// Apply a natural box layout model to all elements
-// from: http://www.paulirish.com/2012/box-sizing-border-box-ftw/
+/* apply a natural box layout model to all elements, but allowing components to change
+   from https://www.paulirish.com/2012/box-sizing-border-box-ftw/
+   update in 2014
+*/
+html {
+  box-sizing: border-box;
+}
 *, *:before, *:after {
-  -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+  box-sizing: inherit;
 }


### PR DESCRIPTION
I saw that there is a bit of CSS copied from a link (which is included in a comment). When I visited the link, the authors mention that their CSS trick has been updated since it was copied to the Jekyll Now repo.
In this PR, I apply the same update to Jekyll Now.