### PR TITLE
Add og:image metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ description: Web Developer from Somewhere
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
 
+# og:image metadata tag image url for social media sharing
+meta_image: #example.jpg
+
 #
 # Flags below are optional
 #

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,3 +16,8 @@
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="twitter:title" content="{{ page.title }}" />
     {% endif %}
+
+    {% if page.meta_image %}
+    <meta property="og:image" content={{ page.meta_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    {% endif %}


### PR DESCRIPTION
Added  meta tags and a site variable for an image url. Allows social media to pull a preview image of your choosing.

`
<meta property="og:image" content="{{ site.meta_image }}">
<meta name="twitter:card" content="summary_large_image">
`

