### PR TITLE
Remove googleplus in config.yml, as it is no longer a service

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,6 @@ footer-links:
   twitter: jekyllrb
   stackoverflow: # your stackoverflow profile, e.g. "users/50476/bart-kiers"
   youtube: # channel/<your_long_string> or user/<user-name>
-  googleplus: # anything in your profile username that comes after plus.google.com/
 
 
 # Enter your Disqus shortname (not your username) to enable commenting on posts


### PR DESCRIPTION
Google Plus shut down a while ago, so it should no longer be on the footer.