### PR TITLE
Counter.dev analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,8 +36,12 @@ footer-links:
 # You can find your shortname on the Settings page of your Disqus account
 disqus:
 
-# Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
+# Analytics:
+## Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics:
+
+## Enter your counter.dev user
+counter_dev: "BillyTheTroll"
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -14,3 +14,9 @@
 	</script>
 	<!-- End Google Analytics -->
 {% endif %}
+
+{% if site.counter_dev %}
+	<!-- Counter.dev Analytics -->
+	<script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"{{ site.counter_dev }}",utcoffset:"2"}))};sessionStorage.setItem("_swa","1");</script>
+	<!-- End Counter.dev Analytics  -->
+{% endif %}


### PR DESCRIPTION
This changes enables to use [counter.dev](https://counter.dev/) for analytics simply by filling the username in the `counter_dev` in the config.yml file.